### PR TITLE
Add shared-exclusive lock to RegexManager's regularExpressionPool

### DIFF
--- a/PhoneNumberKit/RegexManager.swift
+++ b/PhoneNumberKit/RegexManager.swift
@@ -12,6 +12,8 @@ final class RegexManager {
     
     // MARK: Regular expression pool
 
+    private let regularExpressionPoolQueue = DispatchQueue(label: "com.phonenumberkit.regexpool", attributes: .concurrent)
+
     var regularExpresionPool = [String : NSRegularExpression]()
 
     var spaceCharacterSet: CharacterSet = {
@@ -19,30 +21,34 @@ final class RegexManager {
         characterSet.formUnion(with: CharacterSet.whitespacesAndNewlines)
         return characterSet as CharacterSet
     }()
-    
-    deinit {
-        regularExpresionPool.removeAll()
-    }
 
     // MARK: Regular expression
-    
+
     func regexWithPattern(_ pattern: String) throws -> NSRegularExpression {
-        if let regex = regularExpresionPool[pattern] {
+        var cached: NSRegularExpression?
+
+        regularExpressionPoolQueue.sync {
+            cached = self.regularExpresionPool[pattern]
+        }
+
+        if let cached = cached {
+            return cached
+        }
+
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+            regularExpressionPoolQueue.async(flags: .barrier) {
+                self.regularExpresionPool[pattern] = regex
+            }
+
             return regex
         }
-        else {
-            do {
-                let regularExpression: NSRegularExpression
-                regularExpression =  try NSRegularExpression(pattern: pattern, options:NSRegularExpression.Options.caseInsensitive)
-                regularExpresionPool[pattern] = regularExpression
-                return regularExpression
-            }
-            catch {
-                throw PhoneNumberError.generalError
-            }
+        catch {
+            throw PhoneNumberError.generalError
         }
     }
-    
+
     func regexMatches(_ pattern: String, string: String) throws -> [NSTextCheckingResult] {
         do {
             let internalString = string


### PR DESCRIPTION
This makes `PhoneNumberKit.parse()` thread safe. Fixes #193.